### PR TITLE
fix replay_buf_offset ambiguity in BBE

### DIFF
--- a/llk_lib/llk_math_matmul.h
+++ b/llk_lib/llk_math_matmul.h
@@ -264,7 +264,7 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
     const std::uint32_t replay_buf_len = (is_in0_16x32 && is_in1_32x16) ? 4 :
                                          ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 16);
 
-    TT_REPLAY(replay_buf_offset, replay_buf_len, 0, 1);
+    TT_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 1);
 
     if (is_in1_32x16) {
         if (is_in0_16x32) {
@@ -340,7 +340,7 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
 
     // TODO: can we commonize this?
     constexpr uint inner_loops = high_fidelity ? NUM_FIDELITY_PHASES : 1;
-    ckernel_template tmp(1 /* outer loop */, inner_loops, TT_OP_REPLAY(replay_buf_offset, replay_buf_len, 0, 0));
+    ckernel_template tmp(1 /* outer loop */, inner_loops, TT_OP_REPLAY(ckernel::math::replay_buf_offset, replay_buf_len, 0, 0));
 
     if constexpr(high_fidelity) {
         if (t_dim>1) { //

--- a/llk_lib/llk_pack_untilize.h
+++ b/llk_lib/llk_pack_untilize.h
@@ -55,7 +55,7 @@ inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE
 
     if (block_ct_dim != full_ct_dim) {
         const std::uint32_t replay_buf_len = 10;
-        TT_REPLAY(replay_buf_offset, replay_buf_len, 0, 1);
+        TT_REPLAY(ckernel::packer::replay_buf_offset, replay_buf_len, 0, 1);
         TTI_PACR(ADDR_MOD_2, 0, 0xf, 0, 0, 1, 1); // close block
         // update l1 address
         TTI_ADDDMAREG(0, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR_OFFSET);
@@ -95,7 +95,7 @@ inline void _llk_pack_untilize_(const std::uint32_t address, const std::uint32_t
         ckernel::ckernel_template::run(instrn_buffer);
         TTI_ADDRCRXY(p_setadc::PAC, 0, 0, 1, 0, 0b0010); // Read new row in the tile
         if constexpr (block_ct_dim != full_ct_dim) {
-            TTI_REPLAY(replay_buf_offset, 10, 0, 0); // update row address
+            TTI_REPLAY(ckernel::packer::replay_buf_offset, 10, 0, 0); // update row address
         }
     }
 


### PR DESCRIPTION
When building BBE, we get the error: reference to 'replay_buf_offset' is ambiguous.
This is due to replay_buf_offset being defined in both ckernel::math and ckernel::packer.