### PR TITLE
Add sfpu config register init to llk sfpu inits

### DIFF
--- a/llk_lib/llk_math_eltwise_binary_sfpu.h
+++ b/llk_lib/llk_math_eltwise_binary_sfpu.h
@@ -54,6 +54,7 @@ inline void _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_() {
 }
 
 inline void _llk_math_eltwise_binary_sfpu_init_() {
+    sfpu::_init_sfpu_config_reg();
     eltwise_binary_sfpu_configure_addrmod();
     math::reset_counters(p_setrwc::SET_ABD_F);
 }

--- a/llk_lib/llk_math_eltwise_unary_sfpi.h
+++ b/llk_lib/llk_math_eltwise_unary_sfpi.h
@@ -56,6 +56,7 @@ inline void llk_math_eltwise_unary_sfpi(
 
 inline void llk_math_eltwise_unary_sfpi_init(
     uint param0 = 0, uint param1 = 0, uint param2 = 0, uint param3 = 0, uint param4 = 0, uint param5 = 0) {
+    sfpu::_init_sfpu_config_reg();
     eltwise_unary_sfpi_configure_addrmod();
     math::reset_counters(p_setrwc::SET_ABD_F);
 }

--- a/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -63,6 +63,7 @@ inline void _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_() {
 
 template <SfpuType sfpu_op>
 inline void _llk_math_eltwise_unary_sfpu_init_() {
+    sfpu::_init_sfpu_config_reg();
     eltwise_unary_sfpu_configure_addrmod<sfpu_op>();
     math::reset_counters(p_setrwc::SET_ABD_F);
 }


### PR DESCRIPTION
The SFPU config register was not being de-initialized from its prior state in the _llk_math_*_sfpu_init_ calls.
This can cause errors if one OP programs the config reg to a specific mode and the following one does not use that mode.