### PR TITLE
Enable A2D of uint16 datums when Dest is in 32bit mode

### DIFF
--- a/common/inc/cunpack_common.h
+++ b/common/inc/cunpack_common.h
@@ -351,7 +351,7 @@ namespace ckernel::unpacker
       }
       */
       // Workaround for HW bug (int32 dest and movd2a/b is used with srcA/B configured as int8)
-      if (int8_math_enabled) {
+      if (int8_math_enabled || (fp32_dest_acc_en && ((uint)unpA_dst_format == (uint)DataFormat::UInt16))) {
           reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1<<11); // Set debug feature disable bit 11
                                                                  // workaround for bug tenstorrent/budabackend#1948
       }

--- a/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -113,7 +113,7 @@ inline void eltwise_unary_configure_addrmod() {
 }
 
 template <DataCopyType type, BroadcastType bcast_type = BroadcastType::NONE, bool is_fp32_dest_acc_en = false, bool is_int_fpu_en = false>
-inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, const uint num_faces) {
+inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, const uint num_faces, const uint dst_format) {
     // always move 32x32 tile, packed as 16x16x4
 
     if constexpr (type == A2D) {
@@ -121,7 +121,7 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
         uint innerloop = (rows_per_inst == p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
         uint outerloop = num_faces;
 
-        if (is_fp32_dest_acc_en || is_int_fpu_en) {
+        if ((is_fp32_dest_acc_en || is_int_fpu_en) && !(dst_format == (uint)DataFormat::UInt16)) {
             //use elwadd to handle unpacking data into src A as fp16, but dest is in fp32 mode
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
@@ -177,12 +177,12 @@ inline void eltwise_unary_configure_mop(uint rows_per_inst, uint total_rows, con
 
 template <DataCopyType type, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_fp32_dest_acc_en = false, bool is_int_fpu_en = false>
 // within_face_16x16_transpose is used by unpacker, math does not transpose
-inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t transpose_of_faces=0 /*unused*/, const std::uint32_t within_face_16x16_transpose=0 /* unused */, const std::uint32_t num_faces = 4) {
+inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t transpose_of_faces=0 /*unused*/, const std::uint32_t within_face_16x16_transpose=0 /* unused */, const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255) {
 
     eltwise_unary_configure_addrmod<type, src_b_bcast_type>();
 
     if constexpr (type == A2D) {
-        eltwise_unary_configure_mop<type, src_b_bcast_type, is_fp32_dest_acc_en, is_int_fpu_en>(p_mova2d::MOV_8_ROWS, 16, num_faces);
+        eltwise_unary_configure_mop<type, src_b_bcast_type, is_fp32_dest_acc_en, is_int_fpu_en>(p_mova2d::MOV_8_ROWS, 16, num_faces, dst_format);
     } else if constexpr (type == B2D) {
         eltwise_unary_configure_mop<type, src_b_bcast_type>(p_movb2d::MOV_4_ROWS, 16, num_faces);
     } else {


### PR DESCRIPTION
This is needed for typecast op UInt16 -> FP32, because the dest needs to be in 32bit mode.