### PR TITLE
Only round to fp16b when not in approx mode

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -70,7 +70,7 @@ inline void _calculate_reciprocal_(const int iterations)
         }
         v_endif;
 
-        if constexpr (is_fp32_dest_acc_en) {
+        if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
             dst_reg[0] = out;
         } else {
             dst_reg[0] = reinterpret<vFloat>(float_to_fp16b(out, 0));


### PR DESCRIPTION
Ensure RECIP op only rounds when APPROXIMATION_MODE == false