### PR TITLE
fix for pack reconfig for uint8

### DIFF
--- a/common/inc/cpack_common.h
+++ b/common/inc/cpack_common.h
@@ -343,6 +343,12 @@ namespace ckernel::packer
       TTI_REG2FLOP(2,0,0,0,THCON_SEC1_REG1_Row_start_section_size_ADDR32+2-THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
       TTI_REG2FLOP(2,0,0,0,THCON_SEC1_REG8_Row_start_section_size_ADDR32+2-THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
 
+      uint32_t reconfig_PCK_DEST_RD_CTRL_Read_unsigned = 0;
+      if (pack_dst_format == (uint)DataFormat::UInt8) {
+         reconfig_PCK_DEST_RD_CTRL_Read_unsigned = 1;
+      }
+      cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_unsigned_RMW>(reconfig_PCK_DEST_RD_CTRL_Read_unsigned);
+
       if (IS_BFP_FORMAT(pack_dst_format)) {
          // Override exp section size for packers 1,2,3
          // Tile header + exp size + datum size


### PR DESCRIPTION
On packer reconfig, `PCK_DEST_RD_CTRL_Read_unsigned` would not get updated in the case of switching to packing uint8 data, resulting in it being packed out as int8 instead (packed MSB would be taken as sign bit of container rather than the 8th LSB).