### PR TITLE
Shorten the fw code for trisc0

### DIFF
--- a/common/inc/cpack_common.h
+++ b/common/inc/cpack_common.h
@@ -179,8 +179,7 @@ namespace ckernel::packer
       }
 
       config.f.exp_section_size = ((pack_dst_format == (uint)DataFormat::Lf8) || 
-                                   (pack_dst_format == (uint)DataFormat::UInt8) || 
-                                   (pack_dst_format == (uint)DataFormat::Int8)) ? 0 : (partial_face ? 1 : num_faces); // set to num_faces as exp section size is not used for non-bfp formats except for lf8/int8
+                                   ((pack_dst_format & 0xF) == (uint)DataFormat::Int8)) ? 0 : (partial_face ? 1 : num_faces); // set to num_faces as exp section size is not used for non-bfp formats except for lf8/int8
 
       config.f.uncompress   = 1;
       config.f.out_data_format   = pack_dst_format;
@@ -235,8 +234,7 @@ namespace ckernel::packer
 
       dest_rd_ctrl_u dest_rd_ctrl;
       dest_rd_ctrl.val = 0;
-      dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int8) | 
-                                                      (pack_src_format == (uint)DataFormat::UInt8) |
+      dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = ((pack_src_format & 0xF) == (uint)DataFormat::Int8) | 
                                                       (pack_src_format == (uint)DataFormat::Int32) |
                                                       (pack_src_format == (uint)DataFormat::Float32) |
                                                       (is_fp32_dest_acc_en ? 1 : 0);
@@ -345,8 +343,7 @@ namespace ckernel::packer
 
       dest_rd_ctrl_u dest_rd_ctrl;
       dest_rd_ctrl.val = 0;
-      dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int8) | 
-                                                      (pack_src_format == (uint)DataFormat::UInt8) |
+      dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = ((pack_src_format & 0xF) == (uint)DataFormat::Int8) | 
                                                       (pack_src_format == (uint)DataFormat::Int32) |
                                                       (pack_src_format == (uint)DataFormat::Float32) |
                                                       (is_fp32_dest_acc_en ? 1 : 0);
@@ -382,8 +379,7 @@ namespace ckernel::packer
             FWASSERT("Other data formats not supported", false);
          }
       } else if ((pack_dst_format == (uint)DataFormat::Lf8) || 
-                 (pack_dst_format == (uint)DataFormat::Int8) || 
-                 (pack_dst_format == (uint)DataFormat::UInt8)) {
+                 ((pack_dst_format & 0xF) == (uint)DataFormat::Int8)) {
          TTI_REG2FLOP(1,0,0,0,THCON_SEC0_REG1_Row_start_section_size_ADDR32+0-THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
          TTI_REG2FLOP(1,0,0,0,THCON_SEC0_REG8_Row_start_section_size_ADDR32+0-THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
          TTI_REG2FLOP(1,0,0,0,THCON_SEC1_REG1_Row_start_section_size_ADDR32+0-THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);

--- a/common/inc/cunpack_common.h
+++ b/common/inc/cunpack_common.h
@@ -231,10 +231,8 @@ namespace ckernel::unpacker
       alu_config_u alu_payload = {.val = 0};
 
       uint32_t fp32_dest_acc_en = (is_fp32_dest_acc_en) ? (1) : (0);
-      uint32_t int8_math_enabled = ((uint)unpA_dst_format == (uint)DataFormat::Int8) ||
-                                   ((uint)unpB_dst_format == (uint)DataFormat::Int8) ||
-                                   ((uint)unpA_dst_format == (uint)DataFormat::UInt8) ||
-                                   ((uint)unpB_dst_format == (uint)DataFormat::UInt8) ||
+      uint32_t int8_math_enabled = ((uint)(unpA_dst_format & 0xF) == (uint)DataFormat::Int8) ||
+                                   ((uint)(unpB_dst_format & 0xF) == (uint)DataFormat::Int8) ||
                                    ((uint)unpA_dst_format == (uint)DataFormat::Int32) ||
                                    ((uint)unpB_dst_format == (uint)DataFormat::Int32);
 

--- a/llk_lib/llk_unpack_common.h
+++ b/llk_lib/llk_unpack_common.h
@@ -87,8 +87,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(const std::uint32_t unpa
     if ((uint)unpack_src_format == (uint)DataFormat::UInt8) {
         alu_payload.f.ALU_FORMAT_SPEC_REG0_SrcAUnsigned = 1;
     }
-    alu_payload.f.ALU_ACC_CTRL_INT8_math_enabled = ((uint)unpack_dst_format == (uint)DataFormat::Int8) ||
-                                                   ((uint)unpack_dst_format == (uint)DataFormat::UInt8) ||
+    alu_payload.f.ALU_ACC_CTRL_INT8_math_enabled = ((uint)(unpack_dst_format & 0xF) == (uint)DataFormat::Int8) ||
                                                    ((uint)unpack_dst_format == (uint)DataFormat::Int32);
     constexpr uint alu_mask =  ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG0_SrcAUnsigned_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, alu_mask>(alu_payload.val);

--- a/llk_lib/llk_unpack_common.h
+++ b/llk_lib/llk_unpack_common.h
@@ -89,7 +89,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(const std::uint32_t unpa
     }
     alu_payload.f.ALU_ACC_CTRL_INT8_math_enabled = ((uint)(unpack_dst_format & 0xF) == (uint)DataFormat::Int8) ||
                                                    ((uint)unpack_dst_format == (uint)DataFormat::Int32);
-    constexpr uint alu_mask =  ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG0_SrcAUnsigned_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
+    constexpr uint alu_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG0_SrcAUnsigned_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, alu_mask>(alu_payload.val);
     
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);


### PR DESCRIPTION
Shorten TRISC0_FIRMWARE_CODE to help with overflow issues.
Here, I just combined Int8 and UInt8 comparisons into 1 using bitwise and.