### PR TITLE
Optimize trigonometric functions

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -12,7 +12,7 @@
 
 using namespace sfpi;
 
-#define FRAC_2_PI 0.63661975F
+static const float FRAC_2_PI = 0.63661975F;
 
 template <bool APPROXIMATION_MODE>
 static vFloat sfpu_sinpi_2(vFloat x);


### PR DESCRIPTION
Taylor series are only accurate around a single point.  To approximate a function in an interval, we should generate a minimax polynomial with Remez algorithm.

The coefficients in this commit were generated by:
https://gitlab.inria.fr/sfilip/rminimax

That tool is used in the CORE-MATH project, a library of correctly rounded mathematical functions.
https://core-math.gitlabpages.inria.fr/