### PR TITLE
Fix unpacker race condition by putting stall after MMIO

### DIFF
--- a/llk_lib/llk_pack_common.h
+++ b/llk_lib/llk_pack_common.h
@@ -272,32 +272,25 @@ inline void _llk_pack_reduce_mask_config_() {
 }
 
 inline void _llk_pack_reduce_mask_clear_() {
+    // By default, all packers are set to use TILE_ROW_SET_MAPPING_0 and
+    // mask is configured to pass through all the datums
+    pck_edge_offset_u pack_edge_offset = {.val = 0};
+    pack_edge_offset.f.mask = 0xffff;
+
+    // Initialize TMP registers with values we need to write in CFG registers
+    TTI_SETDMAREG(0, LOWER_HALFWORD(pack_edge_offset.val), 0, LO_16(p_gpr_pack::TMP0));
+    TTI_SETDMAREG(0, UPPER_HALFWORD(pack_edge_offset.val), 0, HI_16(p_gpr_pack::TMP0));
+
     // Wait for packer to finish to avoid breaking its current configuration
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
 
-    // By default, all packers are set to use TILE_ROW_SET_MAPPING_0 and
-    // mask is configured to pass through all the datums
     // Clear out packer configuration for reduce
-    TT_RMWCIB0(0xff, 0xff, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);
-    TT_RMWCIB1(0xff, 0xff, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);
-    TT_RMWCIB2(0xff, 0x00, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);
-    TT_RMWCIB3(0xff, 0x00, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);
-
-    TT_RMWCIB0(0xff, 0xff, PCK_EDGE_OFFSET_SEC1_mask_ADDR32);
-    TT_RMWCIB1(0xff, 0xff, PCK_EDGE_OFFSET_SEC1_mask_ADDR32);
-    TT_RMWCIB2(0xff, 0x00, PCK_EDGE_OFFSET_SEC1_mask_ADDR32);
-    TT_RMWCIB3(0xff, 0x00, PCK_EDGE_OFFSET_SEC1_mask_ADDR32);
+    TTI_WRCFG(p_gpr_pack::TMP0,  p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);
+    TTI_WRCFG(p_gpr_pack::TMP0,  p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC1_mask_ADDR32);
 
     // All mappings point to PCK_EDGE_OFFSET_SEC0_mask_ADDR32
-    TT_RMWCIB0(0xff, 0x00, TILE_ROW_SET_MAPPING_0_row_set_mapping_0_ADDR32);
-    TT_RMWCIB1(0xff, 0x00, TILE_ROW_SET_MAPPING_0_row_set_mapping_0_ADDR32);
-    TT_RMWCIB2(0xff, 0x00, TILE_ROW_SET_MAPPING_0_row_set_mapping_0_ADDR32);
-    TT_RMWCIB3(0xff, 0x00, TILE_ROW_SET_MAPPING_0_row_set_mapping_0_ADDR32);
-
-    TT_RMWCIB0(0xff, 0x00, TILE_ROW_SET_MAPPING_1_row_set_mapping_0_ADDR32);
-    TT_RMWCIB1(0xff, 0x00, TILE_ROW_SET_MAPPING_1_row_set_mapping_0_ADDR32);
-    TT_RMWCIB2(0xff, 0x00, TILE_ROW_SET_MAPPING_1_row_set_mapping_0_ADDR32);
-    TT_RMWCIB3(0xff, 0x00, TILE_ROW_SET_MAPPING_1_row_set_mapping_0_ADDR32);
+    TTI_WRCFG(p_gpr::ZERO,  p_cfg::WRCFG_32b, TILE_ROW_SET_MAPPING_0_row_set_mapping_0_ADDR32);
+    TTI_WRCFG(p_gpr::ZERO,  p_cfg::WRCFG_32b, TILE_ROW_SET_MAPPING_1_row_set_mapping_0_ADDR32);
 
     TTI_NOP; TTI_NOP;
 }

--- a/llk_lib/llk_unpack_AB_matmul.h
+++ b/llk_lib/llk_unpack_AB_matmul.h
@@ -236,8 +236,6 @@ inline void _llk_unpack_AB_matmul_(
         // Wait for free context
         wait_for_next_context(2);
 
-        semaphore_post(semaphore::UNPACK_SYNC);  // Trisc::SEMPOST for context acquire
-
         // Program unpacker 1 base address
         if (0 == unp_cfg_context) {
             cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_b;
@@ -246,6 +244,11 @@ inline void _llk_unpack_AB_matmul_(
             cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address_b;
             cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = address_a;
         }
+
+        semaphore_post(semaphore::UNPACK_SYNC);  // Trisc::SEMPOST for context acquire
+
+        // Stall unpacker until pending CFG writes from Trisc have completed
+        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
         if (reuse_a) {
             #if SKIP_UNP == 1


### PR DESCRIPTION
Fix the race condition by introducing a stall. Brought down the semaphore_post right before the stall as this is supposed to have no functional change. Since you cannot write to the address which is currently being used by the unpacker since there is a wait_for_next_context(2) right above it. Context can start from 0, then go to 1 and then come back to 0 and reach the MMIO writes when wait_for_next_context(2) passes, and that happens when the code that was previously working in context 0 has finished. Same argument for context 1.

Reverted the previous workaround change. 