### PR TITLE
Fix load/store mode for add int32

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -17,22 +17,26 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool SIGN_MAGNITUDE_FORMAT, int ITERATIONS>
 inline void _add_int32_(const uint dst_offset) {
+    // Use '12' if Dest is in sign-magnitude format and '4' for 2's complement,
+    // because TTI_SFPIADD requires 2's complement format in LREGs
+    constexpr int sfpload_instr_mod = SIGN_MAGNITUDE_FORMAT ? 12 : 4;
+
     // Operand A is input1 (int32)
     // Operand B is input2 (int32)
     // Output is int32
     #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // operand A - int32 (keep in 2's complement format)
-        TTI_SFPLOAD(0, 4, 3, 0);
-        // operand B - int32 (keep in 2's complement format)
-        TT_SFPLOAD(1, 4, 3, dst_offset * 64);
+        // operand A - int32
+        TTI_SFPLOAD(0, sfpload_instr_mod, 3, 0);
+        // operand B - int32
+        TT_SFPLOAD(1, sfpload_instr_mod, 3, dst_offset * 64);
         TTI_SFPIADD(0, 1, 0, 4);
         // MAD has a 2-cycle pipeline latency so we need one cycle latency until next instr can consume the result
         TTI_NOP;
-        // LREG_0 -> dest as int32 (keep in 2's complement format)
-        TTI_SFPSTORE(0, 4, 3, 0);
+        // LREG_0 -> dest as int32
+        TTI_SFPSTORE(0, sfpload_instr_mod, 3, 0);
         dst_reg++;
     }
 }

--- a/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -24,15 +24,15 @@ inline void _add_int32_(const uint dst_offset) {
     // Output is int32
     #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // operand A - int32
-        TTI_SFPLOAD(0, 12, 3, 0);
-        // operand B - int32
-        TT_SFPLOAD(1, 12, 3, dst_offset * 64);
+        // operand A - int32 (keep in 2's complement format)
+        TTI_SFPLOAD(0, 4, 3, 0);
+        // operand B - int32 (keep in 2's complement format)
+        TT_SFPLOAD(1, 4, 3, dst_offset * 64);
         TTI_SFPIADD(0, 1, 0, 4);
         // MAD has a 2-cycle pipeline latency so we need one cycle latency until next instr can consume the result
         TTI_NOP;
-        // LREG_0 -> dest as int32
-        TTI_SFPSTORE(0, 12, 3, 0);
+        // LREG_0 -> dest as int32 (keep in 2's complement format)
+        TTI_SFPSTORE(0, 4, 3, 0);
         dst_reg++;
     }
 }


### PR DESCRIPTION
Add int32 needs the values in SFPU LREGS to be in 2's complement for negative addition to work properly.