### PR TITLE
#16679: K min values support for TopK

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -384,8 +384,8 @@ inline void _bitonic_topk_phases_steps(
     topk_replay_init = -1;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _bitonic_topk_merge(const bool idir, const int m_iter, const int k)
+template <bool APPROXIMATION_MODE, bool idir, int ITERATIONS>
+inline void _bitonic_topk_merge(const int m_iter, const int k)
 {
     uint dst_addr_offset = 0;
     for (int face=0; face<2; face++) {

--- a/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -385,7 +385,7 @@ inline void _bitonic_topk_phases_steps(
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _bitonic_topk_merge(const int m_iter, const int k)
+inline void _bitonic_topk_merge(const bool idir, const int m_iter, const int k)
 {
     uint dst_addr_offset = 0;
     for (int face=0; face<2; face++) {
@@ -403,7 +403,7 @@ inline void _bitonic_topk_merge(const int m_iter, const int k)
             while (datums_compared < total_datums_to_compare) {
                 for (uint ii=0; ii<inner_d; ii++) {
                     bitonic_topk_load8(dst_offset, ld_dist);
-                    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+                    TT_SFPSWAP(0, !idir ? p_sfpu::LREG0 : p_sfpu::LREG1, !idir ? p_sfpu::LREG1 : p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
                     bitonic_topk_store8(dst_offset, ld_dist);
                     datums_compared += 8;
                     if (ii == (inner_d-1)) {

--- a/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -403,7 +403,7 @@ inline void _bitonic_topk_merge(const int m_iter, const int k)
             while (datums_compared < total_datums_to_compare) {
                 for (uint ii=0; ii<inner_d; ii++) {
                     bitonic_topk_load8(dst_offset, ld_dist);
-                    TT_SFPSWAP(0, !idir ? p_sfpu::LREG0 : p_sfpu::LREG1, !idir ? p_sfpu::LREG1 : p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+                    TTI_SFPSWAP(0, !idir ? p_sfpu::LREG0 : p_sfpu::LREG1, !idir ? p_sfpu::LREG1 : p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
                     bitonic_topk_store8(dst_offset, ld_dist);
                     datums_compared += 8;
                     if (ii == (inner_d-1)) {


### PR DESCRIPTION
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16679)

Ckernel updated to place min values into register instead of max values when flag is set, returning k min values as a result.

[All post commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/12896201187)